### PR TITLE
Added Nullable Reference Type attribute to IKeyValueStore.Get<TData>

### DIFF
--- a/source/Octopus.Configuration/IKeyValueStore.cs
+++ b/source/Octopus.Configuration/IKeyValueStore.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Octopus.Configuration
 {
@@ -6,6 +7,7 @@ namespace Octopus.Configuration
     {
         string? Get(string name, ProtectionLevel protectionLevel = ProtectionLevel.None);
 
+        [return: NotNullIfNotNull("defaultValue")]
         TData Get<TData>(string name, TData defaultValue = default, ProtectionLevel protectionLevel = ProtectionLevel.None);
     }
 }

--- a/source/Octopus.Configuration/NullableReferenceTypeAttributes.cs
+++ b/source/Octopus.Configuration/NullableReferenceTypeAttributes.cs
@@ -1,0 +1,21 @@
+#if !HAS_NULLABLE_REF_TYPES
+using System;
+
+/// <summary>
+/// These attributes replicate the ones from System.Diagnostics.CodeAnalysis, and are here so we can still compile against the older frameworks.
+/// </summary>
+
+namespace Octopus.Configuration
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    public sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName)
+        {
+            this.ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}
+#endif

--- a/source/Octopus.Configuration/Octopus.Configuration.csproj
+++ b/source/Octopus.Configuration/Octopus.Configuration.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <AssemblyName>Octopus.Configuration</AssemblyName>
     <PackageId>Octopus.Configuration</PackageId>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
@@ -13,10 +12,20 @@
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+  <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+    <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <NoWarn>CS8600;CS8601;CS8602;CS8603;CS8604</NoWarn>
+    <DefineConstants>$(DefineConstants);NETFX;FULL_FRAMEWORK</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <DefineConstants>$(DefineConstants);HAS_NULLABLE_REF_TYPES</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Added the `NotNullIfNotNull` attribute to the `Get<TData>`, to specify that a null won't be returned if a non-null `defaultValue` is provided.

There is a hack in here to work around net452, which doesn't have the attribute and makes targeting both frameworks tricky. The csproj has some NoWarn entries added also to handle net452 builds.