### PR TITLE
Update to C# 9

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "5.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/source/Octopus.Configuration/IKeyValueStore.cs
+++ b/source/Octopus.Configuration/IKeyValueStore.cs
@@ -8,6 +8,6 @@ namespace Octopus.Configuration
         string? Get(string name, ProtectionLevel protectionLevel = ProtectionLevel.None);
 
         [return: NotNullIfNotNull("defaultValue")]
-        TData Get<TData>(string name, TData defaultValue = default, ProtectionLevel protectionLevel = ProtectionLevel.None);
+        TData? Get<TData>(string name, TData? defaultValue = default, ProtectionLevel protectionLevel = ProtectionLevel.None);
     }
 }

--- a/source/Octopus.Configuration/Octopus.Configuration.csproj
+++ b/source/Octopus.Configuration/Octopus.Configuration.csproj
@@ -9,7 +9,7 @@
     <Description>Configuration interfaces for Octopus, an opinionated deployment solution for .NET applications</Description>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Copyright>Copyright © Octopus Deploy 2017</Copyright>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">


### PR DESCRIPTION
This PR updates the project file to specify C# 9 and makes a few adjustments to the nullable reference type setup on the generics for the Get method on the key value store.

Addresses issues with Visual Studio, Rider, and builds on certain versions of the build tools.