### PR TITLE
Hand over to core

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_issue.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue.yml
@@ -1,6 +1,6 @@
 name: New Issue
 description: File a new issue
-labels: [state/triage, team/fire-and-motion]
+labels: [state/triage, team/core-platform]
 body:
   - type: markdown
     attributes:

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<packages>
-    <package id="Cake" version="0.38.5" />
-</packages>


### PR DESCRIPTION
_Not much of a PR. Just a slightly formal handover._

# Background

This project was converted from Cake to Nuke along with other pipeline changes as part of the Fire and Motion sensible defaults work. As this falls under the ownership of core platform, we're handing it over.

# Results

Original PR - https://github.com/OctopusDeploy/Configuration/pull/8

## Before

Cake

## After

- Nuke
- [New build in TeamCity](https://build.octopushq.com/project/OctopusDeploy_LIbraries_Configuration?mode=builds)
- [New project in Octopus](https://deploy.octopus.app/app#/Spaces-62/projects/configuration/deployments)

# How to review this PR

Feel free to go through the following

- original PR  (https://github.com/OctopusDeploy/Configuration/pull/8)
- [Build in TeamCity](https://build.octopushq.com/project/OctopusDeploy_LIbraries_Configuration?mode=builds)
- [Project in Octopus](https://deploy.octopus.app/app#/Spaces-62/projects/configuration/deployments)

# After Merging
- [ ] Remove old build in TeamCity.
- [x] Update Slack notification in Octopus to go to Core Platform.
- [x] Update Slack notification in TeamCity to go to Core Platform.
